### PR TITLE
Fix loading screen background color

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -387,7 +387,7 @@ function App() {
 
   if (isLoading) {
     return (
-      <div className="fixed inset-0 bg-gray-50 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-brand-cream z-50 flex items-center justify-center">
         <LoadingSpinner />
       </div>
     );

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,9 +1,6 @@
 export function LoadingSpinner() {
   return (
-    <div
-      className="flex flex-col items-center justify-center py-20"
-      style={{ backgroundColor: "#f9f6ee" }}
-    >
+    <div className="flex flex-col items-center justify-center py-20">
       <div className="mb-6">
         <img
           src="/assets/logo.png"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,6 +9,7 @@ export default {
           dark: "#2a3337",
           light: "#4a5459",
           lighter: "#e8eaeb",
+          cream: "#f9f6ee",
         },
       },
     },


### PR DESCRIPTION
- Add cream color (#f9f6ee) to Tailwind brand colors for reusability
- Update loading screen wrapper to use bg-brand-cream instead of bg-gray-50
- Remove redundant inline background style from LoadingSpinner component
- Ensures consistent warm cream background across entire loading screen

Fixes #41