### PR TITLE
Fix #71: Header buttons park correctly (v1.9.5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,7 @@ The application displays all weather information in a single scrollable page wit
 
 ## Component guidelines
 - **Header**: Uses anchor links for section navigation with sticky positioning
+  - Section anchor targets (`#current`, `#hourly`, `#forecast`, `#monthly`) must keep sticky-header-safe scroll offsets (`scroll-mt-24 md:scroll-mt-28`) so nav buttons park with section titles/content fully visible
 - **LocationSection**: Integrated location display, search, and 4-location history management
 - **WeatherCarousel**: Interactive Embla carousel with 5 cards (current conditions + 3-day forecast + navigation card), supports touch/drag, 2 cards visible on desktop, 1 on mobile, hover-visible navigation arrows
   - Cards use shadow-lg with proper padding to prevent clipping

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-react-typescript-starter",
-  "version": "1.9.4",
+  "version": "1.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-react-typescript-starter",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "license": "MIT",
       "dependencies": {
         "@playwright/test": "^1.57.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-react-typescript-starter",
   "private": true,
-  "version": "1.9.4",
+  "version": "1.9.5",
   "license": "MIT",
   "author": "Spencer Francisco <https://x.com/spencer_i_am>",
   "type": "module",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -641,7 +641,7 @@ function App() {
                     timezone={currentConditions.timezone}
                   />
                 ) : (
-                  <section id="current" className="bg-gray-100">
+                  <section id="current" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
                     <div className="max-w-7xl mx-auto px-4 py-16">
                       <div className="max-w-6xl mx-auto">
                         <div className="text-center">
@@ -661,7 +661,7 @@ function App() {
                     timezone={currentConditions.timezone}
                   />
                 ) : (
-                  <section id="hourly" className="bg-gray-100">
+                  <section id="hourly" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
                     <div className="max-w-7xl mx-auto px-4 py-8">
                       <div className="max-w-6xl mx-auto">
                         <ErrorMessage
@@ -676,7 +676,7 @@ function App() {
                 {forecast.length > 0 ? (
                   <SevenDayForecast forecast={forecast} />
                 ) : (
-                  <section id="forecast" className="bg-gray-100">
+                  <section id="forecast" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
                     <div className="max-w-7xl mx-auto px-4 py-8">
                       <div className="max-w-6xl mx-auto">
                         <ErrorMessage
@@ -691,7 +691,7 @@ function App() {
                 {monthlyForecast ? (
                   <MonthlyForecast forecast={monthlyForecast} />
                 ) : isMonthlyLoading ? (
-                  <section id="monthly" className="bg-gray-100">
+                  <section id="monthly" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
                     <div className="max-w-7xl mx-auto px-4 py-8">
                       <div className="max-w-6xl mx-auto">
                         <div className="bg-brand-cream rounded-lg shadow-md p-8 flex items-center justify-center">
@@ -704,7 +704,7 @@ function App() {
                     </div>
                   </section>
                 ) : monthlyError ? (
-                  <section id="monthly" className="bg-gray-100">
+                  <section id="monthly" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
                     <div className="max-w-7xl mx-auto px-4 py-8">
                       <div className="max-w-6xl mx-auto">
                         <ErrorMessage

--- a/src/components/HourlyForecast.tsx
+++ b/src/components/HourlyForecast.tsx
@@ -63,7 +63,7 @@ export function HourlyForecast({ forecast, timezone }: HourlyForecastProps) {
   }
 
   return (
-    <section id="hourly" className="bg-gray-100">
+    <section id="hourly" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
       <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="max-w-6xl mx-auto">
           <div className="flex justify-between items-center mb-6">

--- a/src/components/MonthlyForecast.tsx
+++ b/src/components/MonthlyForecast.tsx
@@ -37,7 +37,7 @@ export function MonthlyForecast({ forecast }: MonthlyForecastProps) {
   }
 
   return (
-    <section id="monthly" className="bg-gray-100">
+    <section id="monthly" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
       <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-2xl font-semibold text-gray-800 mb-6">

--- a/src/components/SevenDayForecast.tsx
+++ b/src/components/SevenDayForecast.tsx
@@ -11,7 +11,7 @@ export function SevenDayForecast({ forecast }: SevenDayForecastProps) {
   }
 
   return (
-    <section id="forecast" className="bg-gray-100">
+    <section id="forecast" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
       <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-2xl font-semibold text-gray-800 mb-6">

--- a/src/components/WeatherCarousel/WeatherCarousel.tsx
+++ b/src/components/WeatherCarousel/WeatherCarousel.tsx
@@ -87,7 +87,7 @@ export function WeatherCarousel({
   const totalCards = 1 + dailyForecasts.length + 1;
 
   return (
-    <section id="current" className="bg-gray-100">
+    <section id="current" className="bg-gray-100 scroll-mt-24 md:scroll-mt-28">
       <div className="max-w-7xl mx-auto px-4 py-8">
         <div className="max-w-6xl mx-auto">
           {/* Carousel container with navigation arrows */}

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -8,6 +8,17 @@ export interface ChangelogEntry {
 
 export const changelog: ChangelogEntry[] = [
   {
+    version: "1.9.5",
+    date: "February 19, 2026",
+    type: "patch",
+    title: "Header Navigation Parking Fix",
+    changes: [
+      "Fixed header navigation scroll positions so Current, Hourly, 7-Day, and Monthly sections no longer park under the sticky header.",
+      "Applied consistent anchor offset spacing across all weather sections and fallback section states.",
+      "Documented the required section anchor offset convention in AGENTS.md to keep navigation alignment stable in future UI updates.",
+    ],
+  },
+  {
     version: "1.9.4",
     date: "December 9, 2025",
     type: "patch",


### PR DESCRIPTION
## Summary
Fixes issue #71 by making section anchor jumps sticky-header-safe so the target content/title is fully visible after navigation.

## Changes
- Added `scroll-mt-24 md:scroll-mt-28` to all section anchor targets for `current`, `hourly`, `forecast`, and `monthly`.
- Applied the same offsets to fallback section render paths in `App.tsx` for consistent behavior when data is unavailable.
- Updated `AGENTS.md` with a maintenance rule to preserve anchor offsets on future layout changes.
- Added changelog entry and patch version bump to `1.9.5`.

## Validation
- `npm run build` passed.
- `npm run lint` currently reports pre-existing repository lint errors unrelated to this fix.

Closes #71

Created by Zo on behalf of Spencer
